### PR TITLE
Simplify .NET string marshalling

### DIFF
--- a/src/dotnet/Program.cs
+++ b/src/dotnet/Program.cs
@@ -33,17 +33,8 @@ namespace RustTheNewC
             {
                 return null;
             }
-
-            var i = 0;
-            while (Marshal.ReadByte(ptr, i) != 0)
-            {
-                i++;
-            }
-
-            var bytes = new byte[i];
-            Marshal.Copy(ptr, bytes, 0, i);
-
-            return Encoding.UTF8.GetString(bytes, 0, i);
+            
+            return Marshal.PtrToStringAuto(ptr);
         }
     }
 }


### PR DESCRIPTION
Rather than manually marshalling a string from an IntPtr, it's easier to use built in framework utilities like [`Marshal.PtrToStringAuto`](https://docs.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.marshal.ptrtostringauto?redirectedfrom=MSDN&view=netcore-2.2#System_Runtime_InteropServices_Marshal_PtrToStringAuto_System_IntPtr_).